### PR TITLE
Keybinds

### DIFF
--- a/MainWindow/mainwindow.cpp
+++ b/MainWindow/mainwindow.cpp
@@ -10,7 +10,6 @@
 MainWindow::MainWindow(QWidget *parent) :
     QMainWindow(parent),
     ui(new Ui::MainWindow),
-    timerSet(),
     keybindMode(constants::MODE_DEFAULT)
 {
     ui->setupUi(this);

--- a/MainWindow/mainwindow.cpp
+++ b/MainWindow/mainwindow.cpp
@@ -5,10 +5,13 @@
 #include "Utilities/Command/allcommands.h"
 
 #include <QDebug>
+#include <QTimer>
 
 MainWindow::MainWindow(QWidget *parent) :
     QMainWindow(parent),
-    ui(new Ui::MainWindow)
+    ui(new Ui::MainWindow),
+    timerSet(),
+    keybindMode(constants::MODE_DEFAULT)
 {
     ui->setupUi(this);
 
@@ -30,47 +33,45 @@ MainWindow::~MainWindow()
     delete ui;
 }
 
-/* Key Press */
-void MainWindow::keyPressEvent(QKeyEvent *event)
+/* End timer slot */
+void MainWindow::endTimer()
+{
+    qDebug() << "Timer finished, reverting to default mode";
+    keybindMode = constants::MODE_DEFAULT;
+}
+
+/*
+ * Handle a key press in default mode.
+ *
+ * This function will perform the default actions tied to each keybind:
+ *
+ *      Modify
+ *      A-F:    adds statement with that letter
+ *      R:      adds implication/conditional template
+ *      T:      adds biconditional template
+ *      V:      adds or template
+ *      X:      adds cut
+ *      Z:      adds double cut
+ *
+ *      Change mode
+ *      Q:      enters Q mode (press second key to add that letter to tree)
+ */
+void MainWindow::handleKeyPressDefault(QKeyEvent *event)
 {
     ICommand* command;
 
+    // A-F will add that letter as a statement
+    if (event->key() >= 65 && event->key() <= 70)
+    {
+        command = new CTreeStateAddStatement(currentTree,
+                                             event->text().at(0).toUpper());
+        commandInvoker.runCommand(command);
+        return;
+    }
+
+    // Other keys will have more specific functions
     switch (event->key())
     {
-    case Qt::Key_A:
-            qDebug() << "A is pressed";
-            command = new CTreeStateAddStatement(currentTree,"A");
-            commandInvoker.runCommand(command);
-            break;
-    case Qt::Key_Period:
-            qDebug() << ". is pressed";
-            commandInvoker.repeatLastCommand();
-            break;
-    case Qt::Key_B:
-            qDebug() << "B is pressed";
-            command = new CTreeStateAddStatement(currentTree,"B");
-            commandInvoker.runCommand(command);
-            break;
-    case Qt::Key_C:
-            qDebug() << "C is pressed";
-            command = new CTreeStateAddStatement(currentTree,"C");
-            commandInvoker.runCommand(command);
-            break;
-    case Qt::Key_D:
-            qDebug() << "D is pressed";
-            command = new CTreeStateAddStatement(currentTree,"D");
-            commandInvoker.runCommand(command);
-            break;
-    case Qt::Key_E:
-            qDebug() << "E is pressed";
-            command = new CTreeStateAddStatement(currentTree,"E");
-            commandInvoker.runCommand(command);
-            break;
-    case Qt::Key_F:
-            qDebug() << "F is pressed";
-            command = new CTreeStateAddStatement(currentTree,"F");
-            commandInvoker.runCommand(command);
-            break;
     case Qt::Key_J:
             qDebug() << "J is pressed";
             command = new CTreeStateSelectAChild(currentTree);
@@ -91,6 +92,11 @@ void MainWindow::keyPressEvent(QKeyEvent *event)
             command = new CTreeStateSelectRight(currentTree);
             commandInvoker.runCommand(command);
             break;
+    case Qt::Key_Q:
+            qDebug() << "Q is pressed";
+            keybindMode = constants::MODE_Q;
+            QTimer::singleShot(1000,this,SLOT(endTimer()));
+            break;
     case Qt::Key_U:
             qDebug() << "U is pressed";
             commandInvoker.undoLastCommand();
@@ -100,6 +106,10 @@ void MainWindow::keyPressEvent(QKeyEvent *event)
             command = new CTreeStateAddCut(currentTree);
             commandInvoker.runCommand(command);
             break;
+    case Qt::Key_Period:
+            qDebug() << ". is pressed";
+            commandInvoker.repeatLastCommand();
+            break;
     case Qt::Key_Semicolon:
             qDebug() << "; is pressed";
             command = new CTreeStateSelectRoot(currentTree);
@@ -108,4 +118,53 @@ void MainWindow::keyPressEvent(QKeyEvent *event)
     default:
             QMainWindow::keyPressEvent(event);
     }
+
+}
+
+/*
+ * Handle a key press in Q mode.
+ *
+ * Q mode will add a statement with a label corresponding to the next A-Z key
+ * pressed. After hitting any key, the mode reverts to default
+ */
+void MainWindow::handleKeyPressQ(QKeyEvent *event)
+{
+    // Revert the mode
+    keybindMode = constants::MODE_DEFAULT;
+
+    // Check A-Z
+    QString string = event->text();
+    if (string.length() == 1 && string.at(0).isLetter())
+    {
+        ICommand* command = new CTreeStateAddStatement(currentTree,
+                                                       string.toUpper());
+        commandInvoker.runCommand(command);
+        return;
+    }
+    else
+    {
+        qDebug() << "Invalid key press";
+        QMainWindow::keyPressEvent(event);
+        return;
+    }
+
+}
+
+/*
+ * All key presses go here first. The keybindMode will turn the event over to
+ * the proper function for further processing.
+ */
+void MainWindow::keyPressEvent(QKeyEvent *event)
+{
+    // Handle key press based on mode
+    switch (keybindMode)
+    {
+    case constants::MODE_DEFAULT:
+        handleKeyPressDefault(event);
+        break;
+    case constants::MODE_Q:
+        handleKeyPressQ(event);
+        break;
+    }
+
 }

--- a/MainWindow/mainwindow.h
+++ b/MainWindow/mainwindow.h
@@ -27,7 +27,6 @@ private:
     CommandInvoker commandInvoker;
 
     /* Timer */
-    bool timerSet;
     int keybindMode;
 
     /* Key press handlers */
@@ -38,8 +37,6 @@ private:
 private slots:
     void endTimer();
 
-//protected:
-    //void keyPressEvent(QKeyEvent *event);
 };
 
 #endif // MAINWINDOW_MAINWINDOW_H

--- a/MainWindow/mainwindow.h
+++ b/MainWindow/mainwindow.h
@@ -26,8 +26,20 @@ private:
     /* Commands */
     CommandInvoker commandInvoker;
 
-protected:
+    /* Timer */
+    bool timerSet;
+    int keybindMode;
+
+    /* Key press handlers */
     void keyPressEvent(QKeyEvent *event);
+    void handleKeyPressDefault(QKeyEvent *event);
+    void handleKeyPressQ(QKeyEvent *event);
+
+private slots:
+    void endTimer();
+
+//protected:
+    //void keyPressEvent(QKeyEvent *event);
 };
 
 #endif // MAINWINDOW_MAINWINDOW_H

--- a/Utilities/constants.h
+++ b/Utilities/constants.h
@@ -11,10 +11,16 @@ namespace constants
      * ...
      * int x = constants::ELEMENT_ROOT;
      */
+
+    // Tree
     const int ELEMENT_ROOT = 0;
     const int ELEMENT_CUT = 1;
     const int ELEMENT_STATEMENT = 2;
     const int ELEMENT_PLACEHOLDER = 3;
+
+    // Keybind modes
+    const int MODE_DEFAULT = 0;
+    const int MODE_Q = 1;
 }
 
 #endif // UTILITIES_CONSTANTS_H


### PR DESCRIPTION
I added support for keybind modes (only default and q mode at the moment). The mode determines what happens when a certain key is pressed, so that different actions can be performed with the same key depending on the context.

You can view how it works with the newly implemented Q-mode. At the start of the program, the application is in default mode. Pressing Q will set a timer for 1 second, in which the app will switch over to Q-mode. In this mode, the next A-Z character pressed will be added as a statement to the current tree. Pressing an A-Z character will set the mode back to default, regardless of whether the timer has expired or not.

If the timer runs out, the application goes back to default mode, which has all the standard movement, template, A-F statements, and cut controls. 

Basically, pressing Q will enable a short window of time where users can enter any letter as a statement, instead of being restricted to just A-F.

This implementation is not restricted to timers; future plans include a "goal" mode, which will swap between a premise graph and a goal graph. This will be toggled between default mode with the G key, allowing users to see and edit the goal graph as they see fit.